### PR TITLE
Fixed the name of default admin plugin load

### DIFF
--- a/vanilla/sys/application.lua
+++ b/vanilla/sys/application.lua
@@ -387,7 +387,7 @@ function Bootstrap:initView()
 end
 
 function Bootstrap:initPlugin()
-    local admin_plugin = LoadPlugin('plugins.admin'):new()
+    local admin_plugin = LoadPlugin('admin'):new()
     self.dispatcher:registerPlugin(admin_plugin);
 end
 


### PR DESCRIPTION
The name of default admin plugin should be 'admin' , not 'plugins.admin'